### PR TITLE
Fix EOL issue

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -2,7 +2,6 @@ const through2 = require('through2')
 const assign = require('object-assign')
 const PluginError = require('plugin-error')
 const applySourceMap = require('vinyl-sourcemaps-apply')
-const os = require('os')
 
 const terser = require('terser')
 
@@ -64,11 +63,12 @@ function printError(error) {
     return console.error(error.stack || error)
   }
 
-  const fileContent = error.fileContent
-  const lines = fileContent.replace(/\t/g, '    ').split(os.EOL)
+  const fileContent = error.fileContent.replace(/\r/g, '')
+  const lines = fileContent.replace(/\t/g, '    ').split('\n')
   const more = (error.line + ' ').length
   const col = error.col + 1
-  const pos = (more + 2) + fileContent.split(os.EOL)[error.line - 1].replace(/[^\t]/g, '').length * 3 + parseInt(col)
+  const lastline = fileContent.split('\n')[error.line - 1]
+  const pos = (more + 2) + lastline.replace(/[^\t]/g, '').length * 3 + parseInt(col)
 
   console.log(`\nError with ${error.plugin} :`)
   for (let i = error.line - 5; i < error.line; i++) {


### PR DESCRIPTION
Fix #11 


# Q/A : 

Try to build js files with linux eol on Windows.

```json5
{
  "devDependencies": {
    "gulp-teser-js": "git://github.com/A-312/gulp-teser-js.git#fix11"
  }
}
```