### PR TITLE
Add content to sourcemaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,22 @@ gulp.task('minifyJS', minifyJS)
 
 ### Source maps
 
-Terser is automatically configured to support source maps without any additional configuration.
-If the input file has source maps enabled, the Terser `sourceMap` option will be reset and filled with the necessary information.
-This includes the `filename` option, which is set to the previous source map file name, as well as the `content` option, which is set to the incoming source map.
-Terser gets passed these two options, and the resulting source map gets applied to the file.
+When running Terser on compiled Javascript, you may run into issues with source maps.
+If you need to pass the content of your source maps to Terser, first you must set the `loadMaps` option to `true` when initializing `gulp-sourcemaps`.
+Next, make the `content` source map option `true` when piping Terser.
+
+A basic setup may look like this:
+```js
+gulp.src('asset/js/*.js')
+  .pipe(sourcemaps.init({ loadMaps: true }))
+  .pipe(terser({
+     sourceMap: {
+       content: true
+     }
+  }))
+  .pipe(sourcemaps.write())
+  .pipe(gulp.dest('dist'))
+```
 
 ## Can I use terser to format error of an other gulp module ?
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,13 @@ const minifyJS = () =>
 gulp.task('minifyJS', minifyJS)
 ```
 
+### Source maps
+
+Terser is automatically configured to support source maps without any additional configuration.
+If the input file has source maps enabled, the Terser `sourceMap` option will be reset and filled with the necessary information.
+This includes the `filename` option, which is set to the previous source map file name, as well as the `content` option, which is set to the incoming source map.
+Terser gets passed these two options, and the resulting source map gets applied to the file.
+
 ## Can I use terser to format error of an other gulp module ?
 
 ```js

--- a/bin/index.js
+++ b/bin/index.js
@@ -15,6 +15,7 @@ function gulpTerser(options) {
     if (file.sourceMap) {
       opts.sourceMap = {}
       opts.sourceMap.filename = file.sourceMap.file
+      opts.sourceMap.content = file.sourceMap
     }
 
     if (file.sourceMap && file.sourceMap.file) {

--- a/bin/index.js
+++ b/bin/index.js
@@ -13,9 +13,17 @@ function gulpTerser(options) {
     let build = {}
 
     if (file.sourceMap) {
-      opts.sourceMap = {}
-      opts.sourceMap.filename = file.sourceMap.file
-      opts.sourceMap.content = file.sourceMap
+      if (!('sourceMap' in opts)) {
+        opts.sourceMap = {}
+      }
+
+      if (!('filename' in opts.sourceMap)) {
+        opts.sourceMap.filename = file.sourceMap.file
+      }
+
+      if ('content' in opts.sourceMap && typeof opts.sourceMap.content === 'boolean' && opts.sourceMap.content === true) {
+        opts.sourceMap.content = file.sourceMap
+      }
     }
 
     if (file.sourceMap && file.sourceMap.file) {

--- a/test/expect/sm-test/c.js
+++ b/test/expect/sm-test/c.js
@@ -1,0 +1,2 @@
+function o(){console.log("C")}
+//# sourceMappingURL=http://127.0.0.1/fixtures/sm-test/c.js.map

--- a/test/expect/sm-test/c.js.map
+++ b/test/expect/sm-test/c.js.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":["fixtures/sm-test/c.ts"],"names":["C","log"],"mappings":"AAAA,SAASA,YACLC,IAAQ","file":"c.js","sourcesContent":[]}

--- a/test/fixtures/sm-test/c.js
+++ b/test/fixtures/sm-test/c.js
@@ -1,0 +1,4 @@
+function C() {
+  console.log('C')
+}
+//# sourceMappingURL=c.js.map

--- a/test/fixtures/sm-test/c.js.map
+++ b/test/fixtures/sm-test/c.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"c.js","sourceRoot":"","sources":["c.ts"],"names":[],"mappings":"AAAA,SAAS,CAAC;IACN,OAAO,CAAC,GAAG,CAAC,GAAG,CAAC,CAAA;AACpB,CAAC"}


### PR DESCRIPTION
I noticed that the content option is not passed to Terser. I've noticed that in my own projected it gives better results with less duplicate sources and things. Compiling from Typescript then passing that through Terser would give me weird things having do to with multiple sources that are the same file and a null source content. This shouldn't be a breaking change to my knowledge. It would be great to have this because currently my source maps are looking a little strange without it.